### PR TITLE
Register ProcessTools plugins

### DIFF
--- a/src/Commands/CommandManager.cpp
+++ b/src/Commands/CommandManager.cpp
@@ -18,6 +18,8 @@
 #include "../Plugins/ClipboardManager/ClearClipboardCommand.h"
 #include "../Plugins/DeveloperTools/OpenGitBashCommand.h"
 #include "../Plugins/DeveloperTools/OpenPowerShellCommand.h"
+#include "../Plugins/ProcessTools/EnterProcessModeCommand.h"
+#include "../Plugins/ProcessTools/OpenProcessPathCommand.h"
 #include "../Plugins/ProcessTools/TerminateProcessCommand.h"
 #include <vector>
 #include <utility>
@@ -72,9 +74,17 @@ void CommandManager::RegisterDeveloperToolsCommands()
     RegisterCommand(std::make_unique<OpenPowerShellCommand>());
 }
 
+void CommandManager::RegisterProcessToolsCommands()
+{
+    RegisterCommand(std::make_unique<EnterProcessModeCommand>());
+    RegisterCommand(std::make_unique<OpenProcessPathCommand>());
+    RegisterCommand(std::make_unique<TerminateProcessCommand>());
+}
+
 void CommandManager::RegisterAllPlugins()
 {
     RegisterSettingsCommands();
+    RegisterProcessToolsCommands();
     RegisterFileToolsCommands();
     RegisterApplicationLauncherCommands();
     RegisterSystemInfoCommands();

--- a/src/Commands/CommandManager.h
+++ b/src/Commands/CommandManager.h
@@ -38,6 +38,7 @@ public:
     void RegisterNetworkToolsCommands();
     void RegisterClipboardManagerCommands();
     void RegisterDeveloperToolsCommands();
+    void RegisterProcessToolsCommands();
     void RegisterAllPlugins();
     
     // Verbesserte Suchfunktionen

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,9 +17,6 @@
 #include "Commands/CommandManager.h"
 #include "Commands/ICommand.h"
 #include "Commands/ExecutionHistory.h"
-#include "Plugins/ProcessTools/EnterProcessModeCommand.h"
-#include "Plugins/ProcessTools/TerminateProcessCommand.h"
-#include "Plugins/ProcessTools/OpenProcessPathCommand.h"
 #include "Plugins/ApplicationLauncher/GenericLaunchCommand.h"
 
 #pragma comment(lib, "gdiplus.lib")
@@ -866,17 +863,6 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
     return 0;
 }
 
-void RegisterCommands(CommandManager& commandManager)
-{
-    // Register all plugins using the new system
-    commandManager.RegisterAllPlugins();
-    
-    // Register legacy ProcessTools commands (these will be moved to the new system in future)
-    commandManager.RegisterCommand(std::make_unique<EnterProcessModeCommand>());
-    commandManager.RegisterCommand(std::make_unique<OpenProcessPathCommand>());
-    commandManager.RegisterCommand(std::make_unique<TerminateProcessCommand>());
-}
-
 // Entry point for Unicode
 int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PWSTR pCmdLine, int nCmdShow) {
     const wchar_t CLASS_NAME[] = L"CommandPaletteWindow";
@@ -928,7 +914,7 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PWSTR pCmdLine
     DwmSetWindowAttribute(g_hwnd, DWMWA_WINDOW_CORNER_PREFERENCE, &cornerPreference, sizeof(cornerPreference));
 #endif
 
-    RegisterCommands(g_commandManager);
+    g_commandManager.RegisterAllPlugins();
     UpdateFoundCommands(L"");
 
     if (!g_hotkeyManager.RegisterHotkeys(g_hwnd)) {


### PR DESCRIPTION
## Summary
- add ProcessTools plugin registration to CommandManager
- expose RegisterProcessToolsCommands in CommandManager interface
- remove manual ProcessTools command registration from main

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: windows.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688fad2af7708329b29f38d06a0c27f1