### PR TITLE
Add application cache and refresh command

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,6 +26,7 @@ set(SOURCES
     Plugins/ApplicationLauncher/LaunchTaskManagerCommand.cpp
     Plugins/ApplicationLauncher/GenericLaunchCommand.cpp
     Plugins/ApplicationLauncher/ApplicationFinder.cpp
+    Plugins/ApplicationLauncher/RefreshApplicationsCommand.cpp
     Plugins/SystemInfo/ShowSystemInfoCommand.cpp
     Plugins/SystemInfo/ShowDiskUsageCommand.cpp
     Plugins/NetworkTools/ShowNetworkInfoCommand.cpp
@@ -55,6 +56,7 @@ set(HEADERS
     Plugins/ApplicationLauncher/LaunchTaskManagerCommand.h
     Plugins/ApplicationLauncher/GenericLaunchCommand.h
     Plugins/ApplicationLauncher/ApplicationFinder.h
+    Plugins/ApplicationLauncher/RefreshApplicationsCommand.h
     Plugins/SystemInfo/ShowSystemInfoCommand.h
     Plugins/SystemInfo/ShowDiskUsageCommand.h
     Plugins/NetworkTools/ShowNetworkInfoCommand.h

--- a/src/Commands/CommandManager.cpp
+++ b/src/Commands/CommandManager.cpp
@@ -11,6 +11,7 @@
 #include "../Plugins/ApplicationLauncher/LaunchNotepadCommand.h"
 #include "../Plugins/ApplicationLauncher/LaunchTaskManagerCommand.h"
 #include "../Plugins/ApplicationLauncher/GenericLaunchCommand.h"
+#include "../Plugins/ApplicationLauncher/RefreshApplicationsCommand.h"
 #include "../Plugins/SystemInfo/ShowSystemInfoCommand.h"
 #include "../Plugins/SystemInfo/ShowDiskUsageCommand.h"
 #include "../Plugins/NetworkTools/ShowNetworkInfoCommand.h"
@@ -44,7 +45,8 @@ void CommandManager::RegisterApplicationLauncherCommands()
 {
     // Generischer Launch-Befehl (neue Funktionalität)
     RegisterCommand(std::make_unique<GenericLaunchCommand>());
-    
+    RegisterCommand(std::make_unique<RefreshApplicationsCommand>());
+
     // Bestehende spezifische Launch-Befehle (für Kompatibilität beibehalten)
     RegisterCommand(std::make_unique<LaunchCalculatorCommand>());
     RegisterCommand(std::make_unique<LaunchNotepadCommand>());

--- a/src/Plugins/ApplicationLauncher/ApplicationFinder.h
+++ b/src/Plugins/ApplicationLauncher/ApplicationFinder.h
@@ -3,6 +3,7 @@
 #include <vector>
 #include <string>
 #include <memory>
+#include <ctime>
 #include <windows.h>
 
 struct ApplicationInfo {
@@ -63,16 +64,20 @@ struct ApplicationInfo {
 
 class ApplicationFinder {
 public:
-    ApplicationFinder();
-    
+    static ApplicationFinder& Instance();
+
     std::vector<ApplicationInfo> FindApplications(const std::wstring& searchTerm);
     void RefreshApplications();
     size_t GetApplicationCount() const { return m_applications.size(); }
-    
+
 private:
+    ApplicationFinder();
+
     std::vector<ApplicationInfo> m_applications;
     bool m_isInitialized;
-    
+    std::wstring m_cacheFilePath;
+    std::time_t m_cacheTimestamp;
+
     void InitializeApplications();
     void SearchInDirectory(const std::wstring& directory, bool recursive = false);
     void SearchInStartMenu();
@@ -102,4 +107,10 @@ private:
     bool ContainsIgnoreCase(const std::wstring& text, const std::wstring& searchTerm);
     std::wstring GetRegistryString(HKEY hKey, const std::wstring& valueName);
     bool IsValidExecutablePath(const std::wstring& path);
-}; 
+
+    // Cache helpers
+    std::wstring GetCacheFilePath() const;
+    bool LoadCache();
+    void SaveCache() const;
+    std::time_t GetLatestSystemChangeTime() const;
+};

--- a/src/Plugins/ApplicationLauncher/GenericLaunchCommand.cpp
+++ b/src/Plugins/ApplicationLauncher/GenericLaunchCommand.cpp
@@ -5,8 +5,8 @@
 #include <filesystem>
 #include <algorithm>
 
-GenericLaunchCommand::GenericLaunchCommand() 
-    : m_applicationFinder(std::make_unique<ApplicationFinder>()) {
+GenericLaunchCommand::GenericLaunchCommand()
+    : m_applicationFinder(ApplicationFinder::Instance()) {
 }
 
 std::wstring GenericLaunchCommand::GetName() const {
@@ -42,7 +42,7 @@ std::vector<ApplicationInfo> GenericLaunchCommand::GetMatchingApplications() con
         return {};
     }
     
-    auto results = m_applicationFinder->FindApplications(m_currentSearchTerm);
+    auto results = m_applicationFinder.FindApplications(m_currentSearchTerm);
     
     // Ensure all applications have icons loaded
     for (auto& app : results) {

--- a/src/Plugins/ApplicationLauncher/GenericLaunchCommand.h
+++ b/src/Plugins/ApplicationLauncher/GenericLaunchCommand.h
@@ -2,7 +2,6 @@
 
 #include "../../Commands/ICommand.h"
 #include "ApplicationFinder.h"
-#include <memory>
 
 class GenericLaunchCommand : public ICommand {
 public:
@@ -19,7 +18,7 @@ public:
     void LaunchApplication(const ApplicationInfo& app);
     
 private:
-    std::unique_ptr<ApplicationFinder> m_applicationFinder;
+    ApplicationFinder& m_applicationFinder;
     std::wstring m_currentSearchTerm;
     
     // Hilfsmethoden

--- a/src/Plugins/ApplicationLauncher/RefreshApplicationsCommand.cpp
+++ b/src/Plugins/ApplicationLauncher/RefreshApplicationsCommand.cpp
@@ -1,0 +1,17 @@
+#include "RefreshApplicationsCommand.h"
+
+std::wstring RefreshApplicationsCommand::GetName() const {
+    return L"Refresh Applications";
+}
+
+std::wstring RefreshApplicationsCommand::GetDescription() const {
+    return L"Rebuilds the cached application list.";
+}
+
+CommandCategory RefreshApplicationsCommand::GetCategory() const {
+    return CommandCategory::APPLICATION_LAUNCHER;
+}
+
+void RefreshApplicationsCommand::Execute() {
+    ApplicationFinder::Instance().RefreshApplications();
+}

--- a/src/Plugins/ApplicationLauncher/RefreshApplicationsCommand.h
+++ b/src/Plugins/ApplicationLauncher/RefreshApplicationsCommand.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "../../Commands/ICommand.h"
+#include "ApplicationFinder.h"
+
+class RefreshApplicationsCommand : public ICommand {
+public:
+    std::wstring GetName() const override;
+    std::wstring GetDescription() const override;
+    CommandCategory GetCategory() const override;
+    void Execute() override;
+};


### PR DESCRIPTION
## Summary
- Persist discovered applications to a cache file and reload only when underlying directories change
- Add `Refresh Applications` command to rebuild the cache on demand
- Share a singleton `ApplicationFinder` between commands

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: fatal error: windows.h: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_688fbf91513c832988c0fa55b19796e2